### PR TITLE
Maintaining http statuses and redirect location

### DIFF
--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -6,7 +6,10 @@ var requestCount = 0;
 var responseCount = 0;
 var requestIds = [];
 
+var initialResponse = null;
+
 page.onResourceReceived = function (response) {
+    initialResponse = initialResponse || response;
     if(requestIds.indexOf(response.id) !== -1) {
         lastReceived = new Date().getTime();
         responseCount++;
@@ -27,6 +30,7 @@ page.open(system.args[1], function () {
 var checkComplete = function () {
   if(new Date().getTime() - lastReceived > 300 && requestCount === responseCount)  {
     clearInterval(checkCompleteInterval);
+    console.log(JSON.stringify(initialResponse) + "\n\n");
     console.log(page.content);
     phantom.exit();
   } else {

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -4,19 +4,30 @@ var arguments = process.argv.splice(2);
 var port = arguments[0] !== 'undefined' ? arguments[0] : 3000;
 var getContent = function(url, callback) {
   var content = '';
+  var headers = {};
+  var response = {};
   var phantom = require('child_process').spawn('phantomjs', [__dirname + '/phantom-server.js', url]);
   phantom.stdout.setEncoding('utf8');
   phantom.stdout.on('data', function(data) {
-    content += data.toString();
+    data = data.toString();
+    if(match = data.match(/({.*?})\n\n/)) {
+      response = JSON.parse(match[1]);
+      headers.status = response.status;
+      if(response.redirectURL) {
+        headers.location = response.redirectURL;
+      }
+      data = data.replace(/.*?\n\n/, '');
+    }
+    content += data;
   });
   phantom.stderr.on('data', function (data) {
-  console.log('stderr: ' + data);
-});
+    console.log('stderr: ' + data);
+  });
   phantom.on('exit', function(code) {
     if (code !== 0) {
       console.log('We have an error');
     } else {
-      callback(content);
+      callback(headers, content);
     }
   });
 };
@@ -33,8 +44,17 @@ var respond = function (req, res) {
 
   };
   console.log('url:', url);
-  getContent(url, function (content) {
-    res.send(content);
+  getContent(url, function (headers, content) {
+    res.status(headers.status);
+    if(headers.location) {
+      res.set('Location', headers.location);
+    }
+    if(headers.status >= 200 && headers.status < 300) {
+      res.send(content);
+    }
+    else {
+      res.send();
+    }
   });
 }
 


### PR DESCRIPTION
Its is crucial for Google to get the original status codes along with redirect locations when available.

I know the way I transmit the headers to the node process it's not the most elegant one, but it's the less painful for now and also we'll have all headers available for any future needs.

Also in case of a non 2xx response, I omit the content, taken in mind that that would confuse google (imagine a 302 with normal content below (since Phantom will follow the redirection)).

Any feedback will be greatly appreciated :)

Good night!
