### PR TITLE
jshint, debug logging, exit on timeout

### DIFF
--- a/bin/config.json
+++ b/bin/config.json
@@ -1,4 +1,7 @@
 {
-	"url": "http://client.apiengine.io/"
-
+    "url": "http://client.apiengine.io/",
+    "verbose": false,
+    "checkCompleteInterval": 1000,
+    "checkCompleteTimeDiff": 3000,
+    "checkCompleteTimeout": 10000
 }

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,7 +1,7 @@
 {
     "url": "http://client.apiengine.io/",
     "verbose": false,
-    "checkCompleteInterval": 1000,
-    "checkCompleteTimeDiff": 3000,
+    "checkCompleteInterval": 1,
+    "checkCompleteTimeDiff": 300,
     "checkCompleteTimeout": 10000
 }

--- a/bin/seoserver.js
+++ b/bin/seoserver.js
@@ -21,11 +21,4 @@ program
         console.log(__dirname, 'SeoServer successfully started');
     });
 
-program
-    .command('stop')
-    .description('Stops the SeoServer')
-    .action(function() {
-        console.log(__dirname, 'SeoServer stop stub. What should this do?');
-    });
-
 program.parse(process.argv);

--- a/bin/seoserver.js
+++ b/bin/seoserver.js
@@ -1,28 +1,31 @@
 #!/usr/bin/env node
 
-
-
-var program = require('commander');
-var fs = require('fs');
-var forever = require('forever-monitor');
+var program = require('commander'),
+    fs = require('fs'),
+    forever = require('forever-monitor');
 
 // require our seoserver npm package
 
 program
-  .version('0.0.1')
-  .option('-p, --port <location>', 'Specifiy a port to run on')
-
+    .version('0.0.1')
+    .option('-p, --port <location>', 'Specifiy a port to run on');
 
 program
-  .command('start')
-  .description('Starts up an SeoServer on default port 3000')
-  .action(function () {
-    var child = new (forever.Monitor)(__dirname + '/../lib/seoserver.js', {
-      options: [program.port]
+    .command('start')
+    .description('Starts up an SeoServer on default port 3000')
+    .action(function() {
+        var child = new (forever.Monitor)(__dirname + '/../lib/seoserver.js', {
+            options: [program.port]
+        });
+        child.start();
+        console.log(__dirname, 'SeoServer successfully started');
     });
-    child.start();
-    console.log(__dirname, 'SeoServer successfully started');
-  });
+
+program
+    .command('stop')
+    .description('Stops the SeoServer')
+    .action(function() {
+        console.log(__dirname, 'SeoServer stop stub. What should this do?');
+    });
 
 program.parse(process.argv);
-

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -1,37 +1,44 @@
-var page = require('webpage').create();
-var system = require('system');
+var page = require('webpage').create(),
+    system = require('system'),
+    lastReceived = new Date().getTime(),
+    requestCount = 0,
+    responseCount = 0,
+    requestIds = [],
+    checkComplete,
+    checkCompleteInterval;
 
-var lastReceived = new Date().getTime();
-var requestCount = 0;
-var responseCount = 0;
-var requestIds = [];
-
-page.viewportSize = { width: 1024, height: 768 };
-
-page.onResourceReceived = function (response) {
-    if(requestIds.indexOf(response.id) !== -1) {
+page.viewportSize = {width: 1024, height: 768};
+page.onResourceRequested = function(request) {
+    if (requestIds.indexOf(request.id) === -1) {
+        requestIds.push(request.id);
+        requestCount++;
+        console.log('phantom-server:onResourceRequested: request.id: ' + request.id + ' requestCount: ' + requestCount + ' requestIds: ' + requestIds);
+    } else {
+        console.log('phantom-server:onResourceRequested: request.id: ' + request.id + ' requestIds: ' + requestIds);
+    }
+};
+page.onResourceReceived = function(response) {
+    if (requestIds.indexOf(response.id) !== -1) {
         lastReceived = new Date().getTime();
         responseCount++;
         requestIds[requestIds.indexOf(response.id)] = null;
-    }
-};
-page.onResourceRequested = function (request) {
-    if(requestIds.indexOf(request.id) === -1) {
-        requestIds.push(request.id);
-        requestCount++;
+        console.log('phantom-server:onResourceReceived: lastReceived: ' + lastReceived + ' responseCount: ' + responseCount + ' requestIds: ' + requestIds);
+    } else {
+        console.log('phantom-server:onResourceReceived: response.id: ' + response.id + ' requestIds: ' + requestIds);
     }
 };
 
-page.open(system.args[1], function () {
+checkComplete = function () {
+    console.log('phantom-server:checkComplete: ' + new Date().getTime() - lastReceived + ' requestCount: ' + requestCount + ' responseCount: ' + responseCount);
+    if (new Date().getTime() - lastReceived > 300 && requestCount === responseCount) {
+        console.log('phantom-server:checkComplete: Complete.');
+        clearInterval(checkCompleteInterval);
+        console.log(page.content);
+        phantom.exit();
+    } else {
+        console.log('phantom-server:checkComplete: Incomplete...');
+    }
+};
 
-});
-
-var checkComplete = function () {
-  if(new Date().getTime() - lastReceived > 300 && requestCount === responseCount)  {
-    clearInterval(checkCompleteInterval);
-    console.log(page.content);
-    phantom.exit();
-  } else {
-  }
-}
-var checkCompleteInterval = setInterval(checkComplete, 1);
+page.open(system.args[1], function () {});
+checkCompleteInterval = setInterval(checkComplete, 1);

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -37,7 +37,12 @@ checkComplete = function () {
         console.log(page.content);
         phantom.exit();
     } else {
-        console.log('phantom-server:checkComplete: Incomplete... timeDiff: ' + timeDiff);
+        if (timeDiff > 10000) {
+            console.log('phantom-server:checkComplete: FORCED EXIT STATUS 1. Incomplete. timeDiff: ' + timeDiff);
+            phantom.exit(1);
+        } else {
+            console.log('phantom-server:checkComplete: Incomplete... timeDiff: ' + timeDiff);
+        }
     }
 };
 

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -1,5 +1,6 @@
 var page = require('webpage').create(),
     system = require('system'),
+    config = require('../bin/config'),
     lastReceived = new Date().getTime(),
     requestCount = 0,
     responseCount = 0,
@@ -10,41 +11,53 @@ var page = require('webpage').create(),
 page.viewportSize = {width: 1024, height: 768};
 page.onResourceRequested = function(request) {
     if (requestIds.indexOf(request.id) === -1) {
+        if (config.verbose) {
+            console.log('Requested: ' + request.id + ' ' + request.method + ' ' + request.url);
+        }
         requestIds.push(request.id);
         requestCount++;
-        console.log('phantom-server:onResourceRequested: request.id: ' + request.id + ' requestCount: ' + requestCount + ' requestIds: ' + requestIds);
-    } else {
-        console.log('phantom-server:onResourceRequested: request.id: ' + request.id + ' requestIds: ' + requestIds);
     }
 };
 page.onResourceReceived = function(response) {
     if (requestIds.indexOf(response.id) !== -1) {
+        if (config.verbose) {
+            console.log('Received: ' + response.id + ' ' +
+                response.contentType + ' ' +
+                response.url + ' ' +
+                response.bodySize + ' ' +
+                response.stage + ' ' +
+                response.status + ' ' +
+                response.statusText + ' ' +
+                response.redirectURL
+            );
+        }
         lastReceived = new Date().getTime();
         responseCount++;
         requestIds[requestIds.indexOf(response.id)] = null;
-        console.log('phantom-server:onResourceReceived: lastReceived: ' + lastReceived + ' responseCount: ' + responseCount + ' requestIds: ' + requestIds);
-    } else {
-        console.log('phantom-server:onResourceReceived: response.id: ' + response.id + ' requestIds: ' + requestIds);
     }
 };
 
 checkComplete = function () {
     var timeDiff = new Date().getTime() - lastReceived;
-    console.log('phantom-server:checkComplete: ' + timeDiff + ' requestCount: ' + requestCount + ' responseCount: ' + responseCount);
-    if (timeDiff > 300 && requestCount === responseCount) {
-        console.log('phantom-server:checkComplete: Complete. timeDiff: ' + timeDiff);
+    if (timeDiff > config.checkCompleteTimeDiff && requestCount === responseCount) {
         clearInterval(checkCompleteInterval);
         console.log(page.content);
         phantom.exit();
     } else {
-        if (timeDiff > 10000) {
-            console.log('phantom-server:checkComplete: FORCED EXIT STATUS 1. Incomplete. timeDiff: ' + timeDiff);
+        if (timeDiff > config.checkCompleteTimeout) {
+            if (requestCount !== responseCount) {
+                console.log(
+                    'requestCount: ' + requestCount +
+                    ' !== responseCount: ' + responseCount + '.' +
+                    ' You might have a synchronous ajax call that is NOT being captured by onResourceReceived.' +
+                    ' See: https://github.com/ariya/phantomjs/issues/11284'
+                );
+            }
+            console.log('FORCED EXIT STATUS 1. Incomplete in ' + timeDiff + ' seconds.');
             phantom.exit(1);
-        } else {
-            console.log('phantom-server:checkComplete: Incomplete... timeDiff: ' + timeDiff);
         }
     }
 };
 
 page.open(system.args[1], function () {});
-checkCompleteInterval = setInterval(checkComplete, 1000);
+checkCompleteInterval = setInterval(checkComplete, config.checkCompleteInterval);

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -29,16 +29,17 @@ page.onResourceReceived = function(response) {
 };
 
 checkComplete = function () {
-    console.log('phantom-server:checkComplete: ' + new Date().getTime() - lastReceived + ' requestCount: ' + requestCount + ' responseCount: ' + responseCount);
-    if (new Date().getTime() - lastReceived > 300 && requestCount === responseCount) {
-        console.log('phantom-server:checkComplete: Complete.');
+    var timeDiff = new Date().getTime() - lastReceived;
+    console.log('phantom-server:checkComplete: ' + timeDiff + ' requestCount: ' + requestCount + ' responseCount: ' + responseCount);
+    if (timeDiff > 300 && requestCount === responseCount) {
+        console.log('phantom-server:checkComplete: Complete. timeDiff: ' + timeDiff);
         clearInterval(checkCompleteInterval);
         console.log(page.content);
         phantom.exit();
     } else {
-        console.log('phantom-server:checkComplete: Incomplete...');
+        console.log('phantom-server:checkComplete: Incomplete... timeDiff: ' + timeDiff);
     }
 };
 
 page.open(system.args[1], function () {});
-checkCompleteInterval = setInterval(checkComplete, 1);
+checkCompleteInterval = setInterval(checkComplete, 1000);

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -10,17 +10,15 @@ getContent = function(url, callback) {
         phantom = require('child_process').spawn('phantomjs', [__dirname + '/phantom-server.js', url]);
     phantom.stdout.setEncoding('utf8');
     phantom.stdout.on('data', function(data) {
-        console.log('seoserver:PhantomJS stdout: ' + data);
         content += data.toString();
     });
     phantom.stderr.on('data', function(data) {
-        console.log('seoserver:PhantomJS stderr: ' + data);
+        console.log('stderr: ' + data);
     });
     phantom.on('exit', function(code) {
         if (code !== 0) {
-            console.log('seoserver:PhantomJS Exited with code: ' + code);
+            console.log('ERROR: PhantomJS Exited with code: ' + code);
         } else {
-            console.log('seoserver:PhantomJS Exited Successfully. Calling callback with content: ' + content);
             callback(content);
         }
     });
@@ -32,13 +30,11 @@ respond = function(req, res) {
     var url;
     if (req.headers.referer) {
         url = req.headers.referer;
-        console.log('seoserver:url:req.headers.referer:', url);
     }
     if (req.headers['x-forwarded-host']) {
         url = 'http://' + req.headers['x-forwarded-host'] + req.params[0];
-        console.log('seoserver:url:req.headers.x-forwarded-host:', url);
     }
-    console.log('seoserver:url:', url);
+    console.log('url:', url);
     getContent(url, function(content) {
         res.send(content);
     });

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -1,42 +1,48 @@
-var express = require('express');
-var app = express();
-var arguments = process.argv.splice(2);
-var port = arguments[0] !== 'undefined' ? arguments[0] : 3000;
-var getContent = function(url, callback) {
-  var content = '';
-  var phantom = require('child_process').spawn('phantomjs', [__dirname + '/phantom-server.js', url]);
-  phantom.stdout.setEncoding('utf8');
-  phantom.stdout.on('data', function(data) {
-    content += data.toString();
-  });
-  phantom.stderr.on('data', function (data) {
-  console.log('stderr: ' + data);
-});
-  phantom.on('exit', function(code) {
-    if (code !== 0) {
-      console.log('We have an error');
-    } else {
-      callback(content);
-    }
-  });
+var express = require('express'),
+    app = express(),
+    args = process.argv.splice(2),
+    port = args[0] !== 'undefined' ? args[0] : 3000,
+    getContent,
+    respond;
+
+getContent = function(url, callback) {
+    var content = '',
+        phantom = require('child_process').spawn('phantomjs', [__dirname + '/phantom-server.js', url]);
+    phantom.stdout.setEncoding('utf8');
+    phantom.stdout.on('data', function(data) {
+        console.log('seoserver:PhantomJS stdout: ' + data);
+        content += data.toString();
+    });
+    phantom.stderr.on('data', function(data) {
+        console.log('seoserver:PhantomJS stderr: ' + data);
+    });
+    phantom.on('exit', function(code) {
+        if (code !== 0) {
+            console.log('seoserver:PhantomJS Exited with code: ' + code);
+        } else {
+            console.log('seoserver:PhantomJS Exited Successfully. Calling callback with content: ' + content);
+            callback(content);
+        }
+    });
 };
 
-var respond = function (req, res) {
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Headers", "X-Requested-With");
-  var url;
-  if(req.headers.referer) {
-    url = req.headers.referer;
-  }
-  if(req.headers['x-forwarded-host']) {
-    url = 'http://' + req.headers['x-forwarded-host'] + req.params[0];
-
-  };
-  console.log('url:', url);
-  getContent(url, function (content) {
-    res.send(content);
-  });
-}
+respond = function(req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "X-Requested-With");
+    var url;
+    if (req.headers.referer) {
+        url = req.headers.referer;
+        console.log('seoserver:url:req.headers.referer:', url);
+    }
+    if (req.headers['x-forwarded-host']) {
+        url = 'http://' + req.headers['x-forwarded-host'] + req.params[0];
+        console.log('seoserver:url:req.headers.x-forwarded-host:', url);
+    }
+    console.log('seoserver:url:', url);
+    getContent(url, function(content) {
+        res.send(content);
+    });
+};
 
 app.get(/(.*)/, respond);
 app.listen(port);


### PR DESCRIPTION
Hi,

I ran into an issue with phantomjs where a synchronous ajax call is NOT being captured by onResourceReceived which caused the seoserver to balloon out of control never closing phantomjs child processes because the number of requests never matched the number of responses.
See: https://github.com/ariya/phantomjs/issues/11284

In the process of debugging I:
- Cleaned up Javascript var usage and spacing
- Added verbose logging for debugging
- Added config options for verbose logging, checkCompleteInterval, checkCompleteTimeDiff, and checkCompleteTimeout

I found for our js backbone app the 1ms interval and 300ms time lapse to be too quick and moved those variables into the config file so people can tweak them to their needs. I used 1s and 3s (which is probably slower that it needs to be), but that worked well for me. I kept the defaults to the values you currently have (1ms and 300ms). In addition, I added a 10s timeout feature so that it will kill off the phantomjs process if it is waiting for more than 10 seconds (also configurable). If it times out and the requests and responses don't match a message will be logged to help the user check if they perhaps had the same issue I did with a synchronous request that was not calling the onResourceReceived hook.

Setting "verbose" to true in the config will log the request and response details which may help with debugging.

Let me know if you have any questions.

Thanks!
