### PR TITLE
add minResponses and minContentLength; updated config options;

### DIFF
--- a/bin/config.json
+++ b/bin/config.json
@@ -1,7 +1,7 @@
 {
     "url": "http://client.apiengine.io/",
-    "verbose": false,
-    "checkCompleteInterval": 1,
-    "checkCompleteTimeDiff": 300,
+    "verbose": true,
+    "checkCompleteInterval": 300,
+    "checkCompleteTimeDiff": 1000,
     "checkCompleteTimeout": 10000
 }

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,6 +1,8 @@
 {
     "verbose": true,
     "debug": false,
+    "minResponses": 5,
+    "minContentLength": 4000,
     "checkCompleteInterval": 10,
     "checkCompleteTimeDiff": 300,
     "checkCompleteTimeout": 10000

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,7 +1,7 @@
 {
-    "url": "http://client.apiengine.io/",
     "verbose": true,
-    "checkCompleteInterval": 300,
-    "checkCompleteTimeDiff": 1000,
+    "debug": false,
+    "checkCompleteInterval": 10,
+    "checkCompleteTimeDiff": 300,
     "checkCompleteTimeout": 10000
 }

--- a/bin/seoserver.js
+++ b/bin/seoserver.js
@@ -2,7 +2,8 @@
 
 var program = require('commander'),
     fs = require('fs'),
-    forever = require('forever-monitor');
+    forever = require('forever-monitor'),
+    config = require('./config');
 
 // require our seoserver npm package
 
@@ -19,6 +20,7 @@ program
         });
         child.start();
         console.log(__dirname, 'SeoServer successfully started');
+        console.log('With config: ', JSON.stringify(config, null, 4));
     });
 
 program.parse(process.argv);

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -39,7 +39,10 @@ page.onResourceReceived = function(response) {
 
 checkComplete = function () {
     var timeDiff = new Date().getTime() - lastReceived;
-    if (timeDiff > config.checkCompleteTimeDiff && requestCount === responseCount) {
+    if (responseCount >= config.minResponses &&
+        page.content.length >= config.minContentLength &&
+        timeDiff > config.checkCompleteTimeDiff &&
+        requestCount === responseCount) {
         clearInterval(checkCompleteInterval);
         console.log(page.content);
         phantom.exit(0);

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -42,7 +42,7 @@ checkComplete = function () {
     if (timeDiff > config.checkCompleteTimeDiff && requestCount === responseCount) {
         clearInterval(checkCompleteInterval);
         console.log(page.content);
-        phantom.exit();
+        phantom.exit(0);
     } else {
         if (timeDiff > config.checkCompleteTimeout) {
             if (requestCount !== responseCount) {
@@ -53,8 +53,8 @@ checkComplete = function () {
                     ' See: https://github.com/ariya/phantomjs/issues/11284'
                 );
             }
-            console.log('FORCED EXIT STATUS 1. Incomplete in ' + timeDiff + ' seconds.');
-            phantom.exit(1);
+            console.log('FORCED EXIT STATUS 10. Incomplete in ' + timeDiff + ' seconds.');
+            phantom.exit(10);
         }
     }
 };

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -11,8 +11,8 @@ var page = require('webpage').create(),
 page.viewportSize = {width: 1024, height: 768};
 page.onResourceRequested = function(request) {
     if (requestIds.indexOf(request.id) === -1) {
-        if (config.verbose) {
-            console.log('Requested: ' + request.id + ' ' + request.method + ' ' + request.url);
+        if (config.debug) {
+            console.error('Requested: ' + request.id + ' ' + request.method + ' ' + request.url);
         }
         requestIds.push(request.id);
         requestCount++;
@@ -20,8 +20,8 @@ page.onResourceRequested = function(request) {
 };
 page.onResourceReceived = function(response) {
     if (requestIds.indexOf(response.id) !== -1) {
-        if (config.verbose) {
-            console.log('Received: ' + response.id + ' ' +
+        if (config.debug) {
+            console.error('Received: ' + response.id + ' ' +
                 response.contentType + ' ' +
                 response.url + ' ' +
                 response.bodySize + ' ' +
@@ -45,15 +45,15 @@ checkComplete = function () {
         phantom.exit(0);
     } else {
         if (timeDiff > config.checkCompleteTimeout) {
-            if (requestCount !== responseCount) {
-                console.log(
+            if (config.debug) {
+                console.error(
                     'requestCount: ' + requestCount +
                     ' !== responseCount: ' + responseCount + '.' +
                     ' You might have a synchronous ajax call that is NOT being captured by onResourceReceived.' +
                     ' See: https://github.com/ariya/phantomjs/issues/11284'
                 );
+                console.error('FORCED EXIT STATUS 10. Incomplete in ' + timeDiff + ' seconds.');
             }
-            console.log('FORCED EXIT STATUS 10. Incomplete in ' + timeDiff + ' seconds.');
             phantom.exit(10);
         }
     }

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -2,6 +2,7 @@ var express = require('express'),
     app = express(),
     args = process.argv.splice(2),
     port = args[0] !== 'undefined' ? args[0] : 3000,
+    config = require('../bin/config'),
     getContent,
     respond;
 
@@ -13,12 +14,19 @@ getContent = function(url, callback) {
         content += data.toString();
     });
     phantom.stderr.on('data', function(data) {
-        console.log('url: ' + url + ' stderr: ' + data);
+        if (config.verbose) {
+            console.log('url: ' + url + ' stderr: ' + data);
+        }
     });
     phantom.on('exit', function(code) {
         if (code !== 0) {
-            console.log('url: ' + url + ' ERROR: PhantomJS Exited with code: ' + code);
+            if (config.verbose) {
+                console.log('url: ' + url + ' ERROR: PhantomJS Exited with code: ' + code);
+            }
         } else {
+            if (config.verbose) {
+                console.log('url: ' + url + ' HTMLSnapshot completed successfully.');
+            }
             callback(content);
         }
     });

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -25,7 +25,11 @@ getContent = function(url, callback) {
             }
         } else {
             if (config.verbose) {
-                console.log('url: ' + url + ' HTMLSnapshot completed successfully.');
+                console.log(
+                    'url: ' + url +
+                    ' HTMLSnapshot completed successfully.' +
+                    ' Content-Length: ' + content.length
+                );
             }
             callback(content);
         }

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -13,11 +13,11 @@ getContent = function(url, callback) {
         content += data.toString();
     });
     phantom.stderr.on('data', function(data) {
-        console.log('stderr: ' + data);
+        console.log('url: ' + url + ' stderr: ' + data);
     });
     phantom.on('exit', function(code) {
         if (code !== 0) {
-            console.log('ERROR: PhantomJS Exited with code: ' + code);
+            console.log('url: ' + url + ' ERROR: PhantomJS Exited with code: ' + code);
         } else {
             callback(content);
         }


### PR DESCRIPTION
I've added some more config options:
First, I renamed the previous verbose to debug which defaults to false. (should be false in production)
Second, I added a new verbose option which defaults to true and just logs more info about each url that is processed.
minResponses is new and is used as part of the completed processing check for phantom. Users will want to configure this for their app.
minContentLength is also new and used just like minResponses, but checks the Content-Length.
I found sometimes the seoserver was responding before there were enough request/responses and/or the content-length was longer than the default index.html content. Adding these checks made the results a bit more reliable.

I updated the debugging related log messages to use console.error which according to the nodejs docs should print to stderr instead of stdout, but that doesn't seem to be the case. :(
http://nodejs.org/api/stdio.html#stdio_console_error_data
Which is why it is also important that debug is false in production, otherwise a bunch of request/response data will be returned to the search bot.

Let me know if you have questions. The README should get updated (sorry I didn't do that for you).
