### PR TITLE
Removed minResponses and minContentLength from config options and determine them dynamically based on the first and second responses.

### DIFF
--- a/bin/config.json
+++ b/bin/config.json
@@ -1,8 +1,6 @@
 {
     "verbose": true,
     "debug": false,
-    "minResponses": 5,
-    "minContentLength": 4000,
     "checkCompleteInterval": 10,
     "checkCompleteTimeDiff": 300,
     "checkCompleteTimeout": 10000

--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -5,6 +5,8 @@ var page = require('webpage').create(),
     requestCount = 0,
     responseCount = 0,
     requestIds = [],
+    minContentLength,
+    minResponses,
     checkComplete,
     checkCompleteInterval;
 
@@ -31,6 +33,12 @@ page.onResourceReceived = function(response) {
                 response.redirectURL
             );
         }
+        if (response.id === 1) { // first response
+            minContentLength = response.bodySize;
+        }
+        if (responseCount === 1) { // second response
+            minResponses = requestCount;
+        }
         lastReceived = new Date().getTime();
         responseCount++;
         requestIds[requestIds.indexOf(response.id)] = null;
@@ -39,8 +47,8 @@ page.onResourceReceived = function(response) {
 
 checkComplete = function () {
     var timeDiff = new Date().getTime() - lastReceived;
-    if (responseCount >= config.minResponses &&
-        page.content.length >= config.minContentLength &&
+    if (responseCount >= minResponses &&
+        page.content.length >= minContentLength &&
         timeDiff > config.checkCompleteTimeDiff &&
         requestCount === responseCount) {
         clearInterval(checkCompleteInterval);


### PR DESCRIPTION
I think having the minResponses and minContentLength in the config would be annoying and problematic to users over time as well as a barrier to entry. By changing a few lines here we can make some reasonable guesses about what these values should be.

When we get the first response we use the bodySize to set the minContentLength.
When we get the second response we use the current requestCount to set the minResponses.

If there is a desire for configuration here in the future, then we can set it up so that the config overrides the defaults, but I suspect that will be undesirable at the moment.

Let me know if you have any comments, questions, or suggestions.

Thanks!
