### PR TITLE
Handle query string

### DIFF
--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -1,4 +1,5 @@
 var express = require('express'),
+    _url = require('url'),
     app = express(),
     args = process.argv.splice(2),
     port = args[0] !== 'undefined' ? args[0] : 3000,
@@ -44,7 +45,14 @@ respond = function(req, res) {
         url = req.headers.referer;
     }
     if (req.headers['x-forwarded-host']) {
-        url = 'http://' + req.headers['x-forwarded-host'] + req.params[0];
+        var path = req.params[0];
+        var search = _url.parse(req.url).search;
+
+        if (path.charAt(0) === "/") {
+            path = path.substring(1, path.length);
+        }
+
+        url = 'http://' + req.headers['x-forwarded-host'] + '/' + encodeURIComponent(path) + (search ? search : '');
     }
     console.log('url:', url);
     getContent(url, function(content) {


### PR DESCRIPTION
`req.params[0]` is only include a path. Not include a query string.
For example, in requested url is `/path/to/page?q=brabrabra`. Then will be dropping the `?q=brabrabra`.
So, this patch is handling query string from `req.url`.
