### PR TITLE
Change to make it work in apache server with application not located in root of domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-  <h3>Forked version</h3>
-  <p>This is a modified version of seoserver by Thomas Davis. I made this change as the original version doesn't seem to work correctly for me.</p>
-  <p>In order to have this working you need an Apache server with the following config:</p>
-  <code>RewriteEngine on</code><br/>
-	<code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$</code><br/>
-	<code>RewriteRule (.*) http://localhost:3000%{REQUEST_URI}  [P]</code>
-
   <h3>Welcome!</h3>
   <p>Seo Server is a command line tool that runs a server that allows GoogleBot(and any other crawlers) to crawl your heavily Javascript built websites. The tool works with very little changes to your server or client side code.</p>
   <p><i>This entire site is driven by Javascript(view the source or see the <a href="https://github.com/apiengine/seoserver-site">code</a>). Click the `What does Google see?` button at the bottom of each page to see Seo Server in action.</i></p>
@@ -29,20 +22,15 @@
   <code>&lt;meta name="fragment" content="!"&gt;</code>
   <p>Now whenever GoogleBot visits any of our pages it will try to load <code>?_escaped_fragment_=pathname</code></p>
   <p>So if we were using Apache with mod rewrite and mod proxy, we can include in our .htaccess</p>
-  <code>
-    RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$<br />
-    RewriteRule (.*) http://address-of-seoserver:3000/%1? [P]
-  </code>
+  <code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$<br /></code>
+  <code>RewriteRule (.*) http://address-of-seoserver:3000%{REQUEST_URI}  [P]</code>  
   <p>Now all request from GoogleBot will be returned fully rendered. How GoogleBot sees the page can be tested with Google <a href="http://www.google.com/webmasters/">WebMasters</a>(they allow you to simulate Google crawls and see the result instantly).</p>
 
   <h3>For other crawlers</h3>
   <p>
     Using mod rewrite, we can send other crawlers to Seo Server also
   </p>
-  <code>
-    RewriteCond %{HTTP_USER_AGENT} ^DuckDuckBot/1.0;<br />
-    RewriteRule (.*) http://address-of-seoserver:3000/%1? [P]
-
-  </code>
+  <code>RewriteCond %{HTTP_USER_AGENT} ^DuckDuckBot/1.0;</code>
+  <code>RewriteRule (.*) http://address-of-seoserver:3000%{REQUEST_URI}  [P]</code>
   <h3>FAQ</h3>
   <p>Nothing here yet, but check out the examples on the left to see different types of ajaxed content. Also ask questions and give feedback on GitHub <a href="https://github.com/apiengine/seoserver/issues">issues</a>.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <code>&lt;meta name="fragment" content="!"&gt;</code>
   <p>Now whenever GoogleBot visits any of our pages it will try to load <code>?_escaped_fragment_=pathname</code></p>
   <p>So if we were using Apache with mod rewrite and mod proxy, we can include in our .htaccess</p>
-  <code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$<br /></code>
+  <code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$<br /></code><br/>
   <code>RewriteRule (.*) http://address-of-seoserver:3000%{REQUEST_URI}  [P]</code>  
   <p>Now all request from GoogleBot will be returned fully rendered. How GoogleBot sees the page can be tested with Google <a href="http://www.google.com/webmasters/">WebMasters</a>(they allow you to simulate Google crawls and see the result instantly).</p>
 
@@ -30,7 +30,7 @@
   <p>
     Using mod rewrite, we can send other crawlers to Seo Server also
   </p>
-  <code>RewriteCond %{HTTP_USER_AGENT} ^DuckDuckBot/1.0;</code>
+  <code>RewriteCond %{HTTP_USER_AGENT} ^DuckDuckBot/1.0;</code><br/>
   <code>RewriteRule (.*) http://address-of-seoserver:3000%{REQUEST_URI}  [P]</code>
   <h3>FAQ</h3>
   <p>Nothing here yet, but check out the examples on the left to see different types of ajaxed content. Also ask questions and give feedback on GitHub <a href="https://github.com/apiengine/seoserver/issues">issues</a>.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+  <h3>Forked version</h3>
+  <p>This is a modified version of seoserver by Thomas Davis. I made this change as the original version doesn't seem to work correctly for me.</p>
+  <p>In order to have this working you need an Apache server with the following config:</p>
+  <code>
+	RewriteEngine on
+	RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$
+	RewriteRule (.*) http://localhost:3000%{REQUEST_URI}  [P]
+  </code>
+
+
   <h3>Welcome!</h3>
   <p>Seo Server is a command line tool that runs a server that allows GoogleBot(and any other crawlers) to crawl your heavily Javascript built websites. The tool works with very little changes to your server or client side code.</p>
   <p><i>This entire site is driven by Javascript(view the source or see the <a href="https://github.com/apiengine/seoserver-site">code</a>). Click the `What does Google see?` button at the bottom of each page to see Seo Server in action.</i></p>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
   <h3>Forked version</h3>
   <p>This is a modified version of seoserver by Thomas Davis. I made this change as the original version doesn't seem to work correctly for me.</p>
   <p>In order to have this working you need an Apache server with the following config:</p>
-  <code>
-	RewriteEngine on
-	RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$
-	RewriteRule (.*) http://localhost:3000%{REQUEST_URI}  [P]
-  </code>
-
+  <code>RewriteEngine on</code>
+	<code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$</code>
+	<code>RewriteRule (.*) http://localhost:3000%{REQUEST_URI}  [P]</code>
 
   <h3>Welcome!</h3>
   <p>Seo Server is a command line tool that runs a server that allows GoogleBot(and any other crawlers) to crawl your heavily Javascript built websites. The tool works with very little changes to your server or client side code.</p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
   <h3>Forked version</h3>
   <p>This is a modified version of seoserver by Thomas Davis. I made this change as the original version doesn't seem to work correctly for me.</p>
   <p>In order to have this working you need an Apache server with the following config:</p>
-  <code>RewriteEngine on</code>
-	<code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$</code>
+  <code>RewriteEngine on</code><br/>
+	<code>RewriteCond %{QUERY_STRING} ^_escaped_fragment_=(.*)$</code><br/>
 	<code>RewriteRule (.*) http://localhost:3000%{REQUEST_URI}  [P]</code>
 
   <h3>Welcome!</h3>

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -39,17 +39,16 @@ getContent = function(url, callback) {
 respond = function(req, res) {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "X-Requested-With");
-    var url;
-    if (req.headers.referer) {
-        url = req.headers.referer;
-    }
-    if (req.headers['x-forwarded-host']) {
-        url = 'http://' + req.headers['x-forwarded-host'] + req.params[0];
-    }
-    console.log('url:', url);
-    getContent(url, function(content) {
-        res.send(content);
-    });
+	if(req.headers['x-forwarded-host']) {
+		var url = 'http://' + req.headers['x-forwarded-host'] + req.params[0] + "#!" + req.query['_escaped_fragment_'];
+		console.log('url:', url);
+		getContent(url, function(content) {
+			res.send(content);
+		});
+	}
+	else{
+		res.status(500);
+	}
 };
 
 app.get(/(.*)/, respond);

--- a/lib/seoserver.js
+++ b/lib/seoserver.js
@@ -47,6 +47,7 @@ respond = function(req, res) {
 		});
 	}
 	else{
+		console.log('no url');
 		res.status(500);
 	}
 };


### PR DESCRIPTION
I've been trying to make the master branch work without any success. IMHO it has more sense as I've made it in my code:
- In the web server proxying you intercept the request and forward it to the seoserver. The way it was done was not working for me as it was not sending the _escapedfragmet_parameter_ (or any other GET parameter).
- In seoserver you have to restore the original url (as it was before googlebot transformed it by removing the hashbang and setting it as GET parameter) and then push it to the phantomjs service.

In adition I think there were some incorrectly formated statements in the README.MD.

If for some reason this is not a candidate for getting merged into master excuse me. At least I hope it's for some help for someone :-).
