### PR TITLE
Ensures that phantom's output doesn't pollute

### DIFF
--- a/lib/phantom-server.js
+++ b/lib/phantom-server.js
@@ -53,7 +53,10 @@ checkComplete = function () {
         requestCount === responseCount) {
         clearInterval(checkCompleteInterval);
         console.log(page.content);
-        phantom.exit(0);
+        //Ensures that phantom's output doesn't pollute the page content.
+        setTimeout(function () {
+            phantom.exit(0);
+        }, 0);
     } else {
         if (timeDiff > config.checkCompleteTimeout) {
             if (config.debug) {
@@ -65,7 +68,10 @@ checkComplete = function () {
                 );
                 console.error('FORCED EXIT STATUS 10. Incomplete in ' + timeDiff + ' seconds.');
             }
-            phantom.exit(10);
+            //Ensures that phantom's output doesn't pollute the page content.
+            setTimeout(function () {
+                phantom.exit(10);
+            }, 0);
         }
     }
 };


### PR DESCRIPTION
I was getting an issue where after the page's content ends ("/body /html") it was giving me phantomjs errors:

"Unsafe JavaScript attempt to access frame with URL about:blank .."

This prevents the output from showing up by asynchronously calling phantom.exit.

More info:

http://stackoverflow.com/questions/26608391/using-phantomjs-to-embed-all-images-of-a-webpage-produces-warnings-but-works
